### PR TITLE
Removes nginx 1.17 due to EOL

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,29 +9,7 @@ api = "0.2"
   include_files = ["bin/build", "bin/detect", "bin/run", "bin/configure", "buildpack.toml"]
   pre_package = "./scripts/build.sh"
   [metadata.default-versions]
-    nginx = "1.17.*"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2020-05-01T00:00:00Z"
-    id = "nginx"
-    name = "Nginx Server"
-    sha256 = "c072d5dcb1f4efbd757d728dd2778261c070724e060bdeaca89cdfee9e15b0a9"
-    source = "http://nginx.org/download/nginx-1.17.9.tar.gz"
-    source_sha256 = "7dd65d405c753c41b7fdab9415cfb4bdbaf093ec6d9f7432072d52cb7bcbb689"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/nginx/nginx_1.17.9_linux_x64_cflinuxfs3_c072d5dc.tgz"
-    version = "1.17.9"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2020-05-01T00:00:00Z"
-    id = "nginx"
-    name = "Nginx Server"
-    sha256 = "2fe87dae65967cfbbc570f986aa52fc574d6555c71799f2a781487d96c59d26d"
-    source = "http://nginx.org/download/nginx-1.17.10.tar.gz"
-    source_sha256 = "a9aa73f19c352a6b166d78e2a664bb3ef1295bbe6d3cc5aa7404bd4664ab4b83"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/nginx/nginx_1.17.10_linux_x64_cflinuxfs3_2fe87dae.tgz"
-    version = "1.17.10"
+    nginx = "1.19.*"
 
   [[metadata.dependencies]]
     deprecation_date = "2021-05-01T00:00:00Z"
@@ -67,19 +45,13 @@ api = "0.2"
     version = "1.19.1"
 
   [[metadata.dependency_deprecation_dates]]
-    date = 2020-05-01T00:00:00Z
-    link = "https://nginx.org/"
-    name = "nginx"
-    version_line = "1.17.x"
-
-  [[metadata.dependency_deprecation_dates]]
     date = 2021-05-01T00:00:00Z
     link = "https://nginx.org/"
     name = "nginx"
     version_line = "1.18.x"
   [metadata.version-lines]
-    mainline = "1.18.*"
-    stable = "1.17.*"
+    mainline = "1.19.*"
+    stable = "1.18.*"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -1,8 +1,8 @@
 package integration
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -61,9 +61,9 @@ func testLogging(t *testing.T, when spec.G, it spec.S) {
 				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
 				"  Resolving Nginx Server version",
 				"    Candidate version sources (in priority order):",
-				`      buildpack.yml -> "1.18.*"`,
+				`      buildpack.yml -> "1.19.*"`,
 				"",
-				MatchRegexp(`    Selected Nginx Server version \(using buildpack\.yml\): 1\.18\.\d+`),
+				MatchRegexp(`    Selected Nginx Server version \(using buildpack\.yml\): 1\.19\.\d+`),
 				"",
 				"  Executing build process",
 				MatchRegexp(`    Installing Nginx Server \d+\.\d+\.\d+`),


### PR DESCRIPTION
set mainline version to 1.19.x and stable to 1.18.x

Resolves #82 

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>