### PR TITLE
Adds RFC to move from buildpack.yml to environment variables

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,23 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Proposal
+
+{{What changes are you purposing to the overall language family?}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Implementation (Optional)
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+## Source Material (Optional)
+
+{{Any source material used in the creation of the RFC should be put here.}}
+
+## Unresolved Questions and Bikeshedding (Optional)
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{REMOVE THIS SECTION BEFORE RATIFICATION!}}

--- a/rfcs/0001-buildpack-yml-to-env-var.md
+++ b/rfcs/0001-buildpack-yml-to-env-var.md
@@ -1,0 +1,48 @@
+# Buildpack.yml to Environment Variables
+
+## Proposal
+
+Migrate to using environment variables to do all buildpack configuration and
+get rid of `buildpack.yml`.
+
+## Motivation
+
+There are several reasons for making this switch.
+1. There is already an [existing RFC](https://github.com/paketo-buildpacks/rfcs/blob/b885abe5fe0b8f64def4a79f0952b7050f3bee6f/accepted/0003-replace-buildpack-yml.md) that proposes moving away from `buildpack.yml` as a configuration tool.
+1. Environment variables appears to be the standard for configuration in other
+   buildpack ecosystems such as Google Buildpacks and Heroku as well as the
+   Paketo Java buildpacks. Making this change will align the buildpack with the
+   rest of the buildpack ecosystem.
+1. There is native support to pass environment variables to the buildpack
+   either on a per run basis or by configuration that can be checked into
+   source control, in the form of `project.toml`.
+
+## Implementation
+The proposed environment variables for NGINX are as follow:
+
+#### BP_NGINX_VERSION
+```shell
+$BP_NGINX_VERSION="1.17.9"
+```
+This will replace the following structure in `buildpack.yml`:
+```yaml
+nginx:
+  version: 1.17.9
+```
+
+### Deprecation Strategy
+In order to facilitate a smooth transition from `buildpack.yml`, the buildpack
+should will support both configuration options with environment variables
+taking priority or `buildpack.yml` until the 1.0 release of the buildpack. The
+buildpack will detect whether or not the application has a `buildpack.yml` and
+print a warning message which will include links to documentation on how to
+upgrade and how to run builds with environment variable configuration. After
+1.0, having a `buildpack.yml` will cause a detection failure and with a link to
+the same documentation. This behavior will only last until the next minor
+release of the buildpack after which point there will no longer be and error
+but `buildpack.yml` will not be supported.
+
+## Source Material
+* [Google buildpack configuration](https://github.com/GoogleCloudPlatform/buildpacks#language-idiomatic-configuration-options)
+* [Paketo Java configuration](https://paketo.io/docs/buildpacks/language-family-buildpacks/java)
+* [Heroku configuration](https://github.com/heroku/java-buildpack#customizing)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Following the efforts going on in other language families, we should switch to environment variables for this buildpack's configuration.

[Readable](https://github.com/paketo-buildpacks/nginx/blob/env-var-rfc/rfcs/0001-buildpack-yml-to-env-var.md)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
