### PR TITLE
profile script exits 1 if include file isn't found

### DIFF
--- a/cmd/configure/main.go
+++ b/cmd/configure/main.go
@@ -81,6 +81,11 @@ func getIncludedConfs(confText string, confDir string) ([]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get 'include' files for %s: %w", conf, err)
 			}
+
+			if len(matchFiles) == 0 {
+				return nil, fmt.Errorf("failed to get 'include' files for %s: no matching files exist", conf)
+			}
+
 			includeFiles = append(includeFiles, matchFiles...)
 		}
 	}

--- a/cmd/configure/main_test.go
+++ b/cmd/configure/main_test.go
@@ -289,6 +289,21 @@ http {
 					Expect(buffer.String()).To(ContainSubstring(`/\/\/.conf: syntax error in pattern`))
 				})
 			})
+			context("when an include file does not exist", func() {
+				it.Before(func() {
+					Expect(ioutil.WriteFile(filepath.Join(workingDir, "nginx.conf"), []byte("include donotexist.conf;"), 0644)).To(Succeed())
+					command = exec.Command(path, filepath.Join(workingDir, "nginx.conf"), localModulePath, globalModulePath)
+					buffer = bytes.NewBuffer(nil)
+				})
+
+				it("exits non-zero", func() {
+					session, err := gexec.Start(command, buffer, buffer)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(gexec.Exit(1), buffer.String)
+					Expect(buffer.String()).To(ContainSubstring(`failed to get 'include' files for /tmp/working-dir`))
+					Expect(buffer.String()).To(ContainSubstring("no matching files exist"))
+				})
+			})
 		})
 	}, spec.Report(report.Terminal{}))
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #165 (adds check for file existence)

## Use Cases
<!-- An explanation of the use cases your change enables -->
If a user specifies a file or file mask that doesn't correspond to any existing files, the profile script will exit 1 and log an error.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
