### PR TITLE
Revert "fail if no files found matching include directive"

### DIFF
--- a/cmd/configure/main.go
+++ b/cmd/configure/main.go
@@ -81,11 +81,6 @@ func getIncludedConfs(confText string, confDir string) ([]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get 'include' files for %s: %w", conf, err)
 			}
-
-			if len(matchFiles) == 0 {
-				return nil, fmt.Errorf("failed to get 'include' files for %s: no matching files exist", conf)
-			}
-
 			includeFiles = append(includeFiles, matchFiles...)
 		}
 	}

--- a/cmd/configure/main_test.go
+++ b/cmd/configure/main_test.go
@@ -289,21 +289,6 @@ http {
 					Expect(buffer.String()).To(ContainSubstring(`/\/\/.conf: syntax error in pattern`))
 				})
 			})
-			context("when an include file does not exist", func() {
-				it.Before(func() {
-					Expect(ioutil.WriteFile(filepath.Join(workingDir, "nginx.conf"), []byte("include donotexist.conf;"), 0644)).To(Succeed())
-					command = exec.Command(path, filepath.Join(workingDir, "nginx.conf"), localModulePath, globalModulePath)
-					buffer = bytes.NewBuffer(nil)
-				})
-
-				it("exits non-zero", func() {
-					session, err := gexec.Start(command, buffer, buffer)
-					Expect(err).ToNot(HaveOccurred())
-					Eventually(session).Should(gexec.Exit(1), buffer.String)
-					Expect(buffer.String()).To(ContainSubstring(`failed to get 'include' files for /tmp/working-dir`))
-					Expect(buffer.String()).To(ContainSubstring("no matching files exist"))
-				})
-			})
 		})
 	}, spec.Report(report.Terminal{}))
 }


### PR DESCRIPTION
This reverts commit 3744a120b44757797701097b9a7dbf4918716491.

This is to allow downstream buildpacks like php-web that generate
nginx.conf with include masks referring to files/dirs that may not
exist.

See https://github.com/paketo-buildpacks/php-web/blob/v0.0.139/config/nginx.go#L215
Part of #165 

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
