### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -101,12 +101,15 @@ func Build(entryResolver EntryResolver, dependencyService DependencyService, pro
 				{
 					Type:    "web",
 					Command: fmt.Sprintf(`nginx -p $PWD -c "%s"`, nginxConfPath),
+					Default: true,
 				},
 			}
 			launchMetadata.BOM = bom
 		}
 
 		if !shouldInstall(layer.Metadata, currConfigureBinSHA256, dependency.SHA256) {
+			layer.Launch, layer.Build = launch, build
+
 			return packit.BuildResult{
 				Layers: []packit.Layer{layer},
 				Build:  buildMetadata,

--- a/build_test.go
+++ b/build_test.go
@@ -167,6 +167,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "web",
 						Command: fmt.Sprintf(`nginx -p $PWD -c "%s"`, filepath.Join(workspaceDir, "nginx.conf")),
+						Default: true,
 					},
 				},
 			},
@@ -210,7 +211,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(dependencyService.InstallCall.Receives.CnbPath).To(Equal(cnbPath))
 		Expect(dependencyService.InstallCall.Receives.LayerPath).To(Equal(filepath.Join(layersDir, "nginx")))
 		Expect(calculator.SumCall.CallCount).To(Equal(1))
-
 	})
 
 	context("when version source is buildpack.yml", func() {
@@ -298,6 +298,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: fmt.Sprintf(`nginx -p $PWD -c "%s"`, filepath.Join(workspaceDir, "nginx.conf")),
+							Default: true,
 						},
 					},
 				},
@@ -349,14 +350,16 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when rebuilding a layer", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(layersDir, "nginx.toml"), []byte(fmt.Sprintf(`launch = true
-[metadata]
+			err := ioutil.WriteFile(filepath.Join(layersDir, "nginx.toml"), []byte(fmt.Sprintf(`[metadata]
 			dependency-sha = "some-sha"
 			configure-bin-sha = "some-bin-sha"
 			built_at = "%s"
-			`, timeStamp.Format(time.RFC3339Nano))), 0644)
+			`, timeStamp.Format(time.RFC3339Nano))), 0600)
 			Expect(err).NotTo(HaveOccurred())
+
+			entryResolver.MergeLayerTypesCall.Returns.Launch = true
 		})
+
 		it("does not re-build the nginx layer", func() {
 			result, err := build(packit.BuildContext{
 				CNBPath:    cnbPath,
@@ -415,6 +418,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: fmt.Sprintf(`nginx -p $PWD -c "%s"`, filepath.Join(workspaceDir, "nginx.conf")),
+							Default: true,
 						},
 					},
 				},

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/nginx"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
