### PR TITLE
Support BP_WEB_SERVER_LOCATION_PATH env var

### DIFF
--- a/build.go
+++ b/build.go
@@ -52,6 +52,7 @@ type BuildEnvironment struct {
 	WebServerForceHTTPS       bool   `env:"BP_WEB_SERVER_FORCE_HTTPS"`
 	WebServerPushStateEnabled bool   `env:"BP_WEB_SERVER_ENABLE_PUSH_STATE"`
 	WebServerRoot             string `env:"BP_WEB_SERVER_ROOT"`
+	WebServerLocationPath     string `env:"BP_WEB_SERVER_LOCATION_PATH"`
 }
 
 func Build(buildEnv BuildEnvironment,

--- a/default_conf.go
+++ b/default_conf.go
@@ -174,7 +174,7 @@ $((- if (ne .BasicAuthFile "") ))
     auth_basic "Password Protected";
     auth_basic_user_file $(( .BasicAuthFile ));
 $(( end ))
-    location / {
+    location $(( .WebServerLocationPath )) {
 $((- if .WebServerPushStateEnabled ))
       # Send the content at / in response to *any* requested endpoint
       if (!-e $request_filename) {

--- a/default_config_generator.go
+++ b/default_config_generator.go
@@ -35,6 +35,12 @@ func (g DefaultConfigGenerator) Generate(env BuildEnvironment) error {
 
 	g.logs.Subprocess("Setting server root directory to '%s'", env.WebServerRoot)
 
+	if env.WebServerLocationPath == "" {
+		env.WebServerLocationPath = "/"
+	}
+
+	g.logs.Subprocess("Setting server location path to '%s'", env.WebServerLocationPath)
+
 	if env.WebServerPushStateEnabled {
 		g.logs.Subprocess("Enabling push state routing")
 	}

--- a/default_config_generator_test.go
+++ b/default_config_generator_test.go
@@ -251,6 +251,19 @@ error_log stderr;
 			Expect(string(contents)).To(ContainSubstring(`root /some/absolute/path;`))
 		})
 
+		it("writes a nginx.conf with specified location path", func() {
+			err := generator.Generate(nginx.BuildEnvironment{
+				ConfLocation:          filepath.Join(workingDir, "nginx.conf"),
+				WebServerLocationPath: "/path",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(filepath.Join(workingDir, "nginx.conf")).To(BeARegularFile())
+			contents, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(ContainSubstring(`location /path {`))
+		})
+
 		it("writes an nginx.conf that conditionally includes the PushState content", func() {
 			err := generator.Generate(nginx.BuildEnvironment{
 				ConfLocation:              filepath.Join(workingDir, "nginx.conf"),

--- a/integration/no_conf_app_test.go
+++ b/integration/no_conf_app_test.go
@@ -69,6 +69,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Generating /workspace/nginx.conf",
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
+				"    Setting server location path to '/'",
 				"",
 			))
 
@@ -97,6 +98,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				WithEnv(map[string]string{
 					"BP_WEB_SERVER":                   "nginx",
 					"BP_WEB_SERVER_ROOT":              "custom_root",
+					"BP_WEB_SERVER_LOCATION_PATH":     "/custom_path",
 					"BP_WEB_SERVER_ENABLE_PUSH_STATE": "true",
 				}).
 				WithPullPolicy("never").
@@ -112,12 +114,13 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Generating /workspace/nginx.conf",
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/custom_root'`,
+				"    Setting server location path to '/custom_path'",
 				"    Enabling push state routing",
 				"",
 			))
 
-			Eventually(container).Should(Serve(ContainSubstring("<p>Hello World!</p>")).OnPort(8080))
-			Eventually(container).Should(Serve(ContainSubstring("<p>Hello World!</p>")).OnPort(8080).WithEndpoint("/test"))
+			Eventually(container).Should(Serve(ContainSubstring("<p>Hello World!</p>")).OnPort(8080).WithEndpoint("/custom_path"))
+			Eventually(container).Should(Serve(ContainSubstring("<p>Hello World!</p>")).OnPort(8080).WithEndpoint("/custom_path/test"))
 		})
 	})
 
@@ -140,6 +143,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Generating /workspace/nginx.conf",
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
+				"    Setting server location path to '/'",
 				`    Setting server to redirect HTTP requests to HTTPS`,
 				"",
 			))
@@ -194,6 +198,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Generating /workspace/nginx.conf",
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
+				"    Setting server location path to '/'",
 				`    Enabling basic authentication with .htpasswd credentials`,
 				"",
 			))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The PR add the support of an env var named BP_WEB_SERVER_LOCATION_PATH to support hosting application from a subpath

## Use Cases
<!-- An explanation of the use cases your change enables -->
When hosting a staticapp under a subpath is important that nginx is configured appropriately.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
