### PR TITLE
Allows UIDs to differ between build/run images

### DIFF
--- a/build.go
+++ b/build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -125,6 +126,23 @@ func Build(buildEnv BuildEnvironment,
 			}
 		}
 
+		confs, err := getIncludedConfs(buildEnv.ConfLocation)
+		if err != nil {
+			return packit.BuildResult{}, fmt.Errorf("failed to find configuration files: %w", err)
+		}
+
+		for _, path := range append([]string{buildEnv.ConfLocation}, confs...) {
+			info, err := os.Stat(path)
+			if err != nil {
+				return packit.BuildResult{}, fmt.Errorf("failed to stat configuration files: %w", err)
+			}
+
+			err = os.Chmod(path, info.Mode()|0060)
+			if err != nil {
+				return packit.BuildResult{}, fmt.Errorf("failed to chmod configuration files: %w", err)
+			}
+		}
+
 		layer, err := context.Layers.Get(NGINX)
 		if err != nil {
 			return packit.BuildResult{}, err
@@ -143,10 +161,9 @@ func Build(buildEnv BuildEnvironment,
 		if launch {
 			command := "nginx"
 			args := []string{
-				"-p",
-				context.WorkingDir,
-				"-c",
-				buildEnv.ConfLocation,
+				"-p", context.WorkingDir,
+				"-c", buildEnv.ConfLocation,
+				"-g", "pid /tmp/nginx.pid;",
 			}
 			launchMetadata.Processes = []packit.Process{
 				{
@@ -273,4 +290,32 @@ func shouldInstall(layerMetadata map[string]interface{}, configBinSHA256, depend
 	}
 
 	return false
+}
+
+var IncludeConfRegexp = regexp.MustCompile(`include\s+(\S*.conf);`)
+
+func getIncludedConfs(path string) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read config file (%s): %w", path, err)
+	}
+
+	var files []string
+	for _, match := range IncludeConfRegexp.FindAllStringSubmatch(string(content), -1) {
+		if len(match) == 2 {
+			glob := match[1]
+			if !filepath.IsAbs(glob) {
+				glob = filepath.Join(filepath.Dir(path), glob)
+			}
+
+			matches, err := filepath.Glob(glob)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get 'include' files for %s: %w", glob, err)
+			}
+
+			files = append(files, matches...)
+		}
+	}
+
+	return files, nil
 }

--- a/build_test.go
+++ b/build_test.go
@@ -92,16 +92,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		bindings = &fakes.Bindings{}
-
 		config = &fakes.ConfigGenerator{}
-
 		calculator = &fakes.Calculator{}
-
 		calculator.SumCall.Returns.String = "some-bin-sha"
 
 		// create fake configure binary
 		Expect(os.Mkdir(filepath.Join(cnbPath, "bin"), os.ModePerm)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(cnbPath, "bin", "configure"), []byte("binary-contents"), 0600)).To(Succeed())
+
+		Expect(os.WriteFile(filepath.Join(workspaceDir, "nginx.conf"), []byte("worker_processes 2;"), 0600)).To(Succeed())
 
 		build = nginx.Build(nginx.BuildEnvironment{}, entryResolver, dependencyService, bindings, config, calculator, scribe.NewEmitter(buffer), chronos.DefaultClock)
 	})
@@ -167,10 +166,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Type:    "web",
 				Command: "nginx",
 				Args: []string{
-					"-p",
-					workspaceDir,
-					"-c",
-					filepath.Join(workspaceDir, nginx.ConfFile),
+					"-p", workspaceDir,
+					"-c", filepath.Join(workspaceDir, nginx.ConfFile),
+					"-g", "pid /tmp/nginx.pid;",
 				},
 				Direct:  true,
 				Default: true,
@@ -249,10 +247,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"--shell", "none",
 						"--",
 						"nginx",
-						"-p",
-						workspaceDir,
-						"-c",
-						filepath.Join(workspaceDir, nginx.ConfFile),
+						"-p", workspaceDir,
+						"-c", filepath.Join(workspaceDir, nginx.ConfFile),
+						"-g", "pid /tmp/nginx.pid;",
 					},
 					Direct:  true,
 					Default: true,
@@ -261,10 +258,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Type:    "no-reload",
 					Command: "nginx",
 					Args: []string{
-						"-p",
-						workspaceDir,
-						"-c",
-						filepath.Join(workspaceDir, nginx.ConfFile),
+						"-p", workspaceDir,
+						"-c", filepath.Join(workspaceDir, nginx.ConfFile),
+						"-g", "pid /tmp/nginx.pid;",
 					},
 					Direct: true,
 				},
@@ -355,10 +351,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Type:    "web",
 					Command: "nginx",
 					Args: []string{
-						"-p",
-						workspaceDir,
-						"-c",
-						filepath.Join(workspaceDir, nginx.ConfFile),
+						"-p", workspaceDir,
+						"-c", filepath.Join(workspaceDir, nginx.ConfFile),
+						"-g", "pid /tmp/nginx.pid;",
 					},
 					Direct:  true,
 					Default: true,
@@ -473,10 +468,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Type:    "web",
 					Command: "nginx",
 					Args: []string{
-						"-p",
-						workspaceDir,
-						"-c",
-						filepath.Join(workspaceDir, nginx.ConfFile),
+						"-p", workspaceDir,
+						"-c", filepath.Join(workspaceDir, nginx.ConfFile),
+						"-g", "pid /tmp/nginx.pid;",
 					},
 					Direct:  true,
 					Default: true,
@@ -493,6 +487,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				ConfLocation: "some-relative-path/nginx.conf",
 			}
 			build = nginx.Build(buildEnv, entryResolver, dependencyService, bindings, config, calculator, scribe.NewEmitter(buffer), chronos.DefaultClock)
+
+			Expect(os.Mkdir(filepath.Join(workspaceDir, "some-relative-path"), os.ModePerm)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workspaceDir, "some-relative-path", "nginx.conf"), []byte("worker_processes 2;"), 0600)).To(Succeed())
 		})
 
 		it("assumes path is relative to /workspace", func() {
@@ -515,7 +512,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Layers: packit.Layers{Path: layersDir},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Launch.Processes[0].Args[len(result.Launch.Processes[0].Args)-1]).To(Equal(filepath.Join(workspaceDir, "some-relative-path", "nginx.conf")))
+			Expect(result.Launch.Processes[0].Args).To(Equal([]string{
+				"-p", workspaceDir,
+				"-c", filepath.Join(workspaceDir, "some-relative-path", "nginx.conf"),
+				"-g", "pid /tmp/nginx.pid;",
+			}))
 			Expect(result.Layers[0].LaunchEnv).To(Equal(packit.Environment{
 				"EXECD_CONF.override": filepath.Join(workspaceDir, "some-relative-path/nginx.conf"),
 			}))
@@ -525,9 +526,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("when BP_NGINX_CONF_LOCATION is set to an absolute path", func() {
 		it.Before(func() {
 			buildEnv := nginx.BuildEnvironment{
-				ConfLocation: "/some-absolute-path/nginx.conf",
+				ConfLocation: filepath.Join(workspaceDir, "some-absolute-path", "nginx.conf"),
 			}
 			build = nginx.Build(buildEnv, entryResolver, dependencyService, bindings, config, calculator, scribe.NewEmitter(buffer), chronos.DefaultClock)
+
+			Expect(os.Mkdir(filepath.Join(workspaceDir, "some-absolute-path"), os.ModePerm)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workspaceDir, "some-absolute-path", "nginx.conf"), []byte("worker_processes 2;"), 0600)).To(Succeed())
 		})
 
 		it("uses the location as-is", func() {
@@ -550,9 +554,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Layers: packit.Layers{Path: layersDir},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Launch.Processes[0].Args[len(result.Launch.Processes[0].Args)-1]).To(Equal("/some-absolute-path/nginx.conf"))
+			Expect(result.Launch.Processes[0].Args).To(Equal([]string{
+				"-p", workspaceDir,
+				"-c", filepath.Join(workspaceDir, "some-absolute-path", "nginx.conf"),
+				"-g", "pid /tmp/nginx.pid;",
+			}))
 			Expect(result.Layers[0].LaunchEnv).To(Equal(packit.Environment{
-				"EXECD_CONF.override": "/some-absolute-path/nginx.conf",
+				"EXECD_CONF.override": filepath.Join(workspaceDir, "some-absolute-path", "nginx.conf"),
 			}))
 		})
 	})
@@ -560,7 +568,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("when BP_WEB_SERVER=nginx in the build env", func() {
 		it.Before(func() {
 			buildEnv := nginx.BuildEnvironment{
-				ConfLocation:  "some-relative-path/nginx.conf",
 				WebServer:     "nginx",
 				WebServerRoot: "custom",
 			}
@@ -589,14 +596,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.GenerateCall.Receives.Env).To(Equal(nginx.BuildEnvironment{
-				ConfLocation:  filepath.Join(workspaceDir, "some-relative-path/nginx.conf"),
+				ConfLocation:  filepath.Join(workspaceDir, "nginx.conf"),
 				WebServer:     "nginx",
 				WebServerRoot: "custom",
 			}))
 
 			Expect(result.Layers[0].LaunchEnv).To(Equal(packit.Environment{
 				"APP_ROOT.override":   workspaceDir, // generated nginx conf relies on this env var
-				"EXECD_CONF.override": filepath.Join(workspaceDir, "some-relative-path/nginx.conf"),
+				"EXECD_CONF.override": filepath.Join(workspaceDir, "nginx.conf"),
 			}))
 		})
 
@@ -656,9 +663,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 				entryResolver.MergeLayerTypesCall.Returns.Launch = true
 			})
+
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(layersDir, "nginx.toml"))).To(Succeed())
 			})
+
 			it("still generates the nginx.conf file", func() {
 				_, err := build(packit.BuildContext{
 					CNBPath:    cnbPath,
@@ -681,11 +690,39 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.GenerateCall.Receives.Env).To(Equal(nginx.BuildEnvironment{
-					ConfLocation:  filepath.Join(workspaceDir, "some-relative-path/nginx.conf"),
+					ConfLocation:  filepath.Join(workspaceDir, "nginx.conf"),
 					WebServer:     "nginx",
 					WebServerRoot: "custom",
 				}))
 			})
+		})
+	})
+
+	context("when the nginx.conf and included files need their permissions set", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workspaceDir, "nginx.conf"), []byte("include custom.conf;"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workspaceDir, "custom.conf"), []byte("worker_processes 2;"), 0600)).To(Succeed())
+		})
+
+		it("modifies their permissions to be group read-writable", func() {
+			_, err := build(packit.BuildContext{
+				CNBPath:    cnbPath,
+				WorkingDir: workspaceDir,
+				Stack:      "some-stack",
+				Plan: packit.BuildpackPlan{
+					Entries: []packit.BuildpackPlanEntry{{Name: "nginx"}},
+				},
+				Layers: packit.Layers{Path: layersDir},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			info, err := os.Stat(filepath.Join(workspaceDir, "nginx.conf"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().String()).To(Equal("-rw-rw----"))
+
+			info, err = os.Stat(filepath.Join(workspaceDir, "custom.conf"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().String()).To(Equal("-rw-rw----"))
 		})
 	})
 
@@ -838,7 +875,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns an error", func() {
 				_, err := build(packit.BuildContext{
-					CNBPath: cnbPath,
+					CNBPath:    cnbPath,
+					WorkingDir: workspaceDir,
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{Name: "nginx"},
@@ -881,7 +919,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns an error", func() {
 				_, err := build(packit.BuildContext{
-					CNBPath: cnbPath,
+					CNBPath:    cnbPath,
+					WorkingDir: workspaceDir,
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{Name: "nginx"},
@@ -901,7 +940,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns an error", func() {
 				_, err := build(packit.BuildContext{
-					CNBPath: cnbPath,
+					CNBPath:    cnbPath,
+					WorkingDir: workspaceDir,
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{Name: "nginx"},
@@ -921,7 +961,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns an error", func() {
 				_, err := build(packit.BuildContext{
-					CNBPath: cnbPath,
+					CNBPath:    cnbPath,
+					WorkingDir: workspaceDir,
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{Name: "nginx"},
@@ -932,7 +973,28 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				})
 				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 			})
+		})
 
+		context("when the included confs cannot be fetched", func() {
+			it.Before(func() {
+				Expect(os.Remove(filepath.Join(workspaceDir, "nginx.conf"))).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := build(packit.BuildContext{
+					CNBPath:    cnbPath,
+					WorkingDir: workspaceDir,
+					Plan: packit.BuildpackPlan{
+						Entries: []packit.BuildpackPlanEntry{
+							{Name: "nginx"},
+						},
+					},
+					Layers: packit.Layers{Path: layersDir},
+					Stack:  "some-stack",
+				})
+				Expect(err).To(MatchError(ContainSubstring("failed to find configuration files")))
+				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+			})
 		})
 	})
 }

--- a/cmd/configure/internal/run_test.go
+++ b/cmd/configure/internal/run_test.go
@@ -244,5 +244,4 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
-
 }

--- a/default_conf.go
+++ b/default_conf.go
@@ -6,9 +6,6 @@ worker_processes 1;
 # Run NGINX in foreground (necessary for containerized NGINX)
 daemon off;
 
-# Set the location of the server's PID file
-pid {{ tempDir }}/nginx.pid;
-
 # Set the location of the server's error log
 error_log stderr;
 

--- a/default_config_generator_test.go
+++ b/default_config_generator_test.go
@@ -51,9 +51,6 @@ worker_processes 1;
 # Run NGINX in foreground (necessary for containerized NGINX)
 daemon off;
 
-# Set the location of the server's PID file
-pid {{ tempDir }}/nginx.pid;
-
 # Set the location of the server's error log
 error_log stderr;
 

--- a/integration.json
+++ b/integration.json
@@ -1,3 +1,3 @@
 {
-    "watchexec": "github.com/paketo-buildpacks/watchexec"
+  "watchexec": "github.com/paketo-buildpacks/watchexec"
 }

--- a/integration/no_conf_app_test.go
+++ b/integration/no_conf_app_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/v2/fs"
-
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -57,6 +56,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				err  error
 				logs fmt.Stringer
 			)
+
 			image, logs, err = pack.Build.
 				WithBuildpacks(nginxBuildpack).
 				WithEnv(map[string]string{
@@ -88,11 +88,13 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(fs.Copy(filepath.Join(source, "public"), filepath.Join(source, "custom_root"))).To(Succeed())
 			os.RemoveAll(filepath.Join(source, "public"))
 		})
+
 		it("generates an nginx.conf with the configuration", func() {
 			var (
 				err  error
 				logs fmt.Stringer
 			)
+
 			image, logs, err = pack.Build.
 				WithBuildpacks(nginxBuildpack).
 				WithEnv(map[string]string{
@@ -130,6 +132,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				err  error
 				logs fmt.Stringer
 			)
+
 			image, logs, err = pack.Build.
 				WithBuildpacks(nginxBuildpack).
 				WithEnv(map[string]string{
@@ -163,11 +166,10 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			response, err := client.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
-
 			Expect(response.StatusCode).To(Equal(http.StatusMovedPermanently))
 
-			_, err = http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			// Assert that the server attempts to hit HTTPS URL instead of HTTP
+			_, err = http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 			Expect(err).To(MatchError(`Get "https://localhost/": dial tcp [::1]:443: connect: connection refused`))
 		})
 	})
@@ -184,6 +186,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				err  error
 				logs fmt.Stringer
 			)
+
 			image, logs, err = pack.Build.
 				WithBuildpacks(nginxBuildpack).
 				WithEnv(map[string]string{

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -156,11 +156,14 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			Eventually(noReloadContainer).Should(BeAvailable())
 			Eventually(noReloadContainer).Should(Serve(ContainSubstring("Hello World!")).WithEndpoint("/index.html"))
 
-			Expect(logs).To(ContainLines("  Assigning launch processes:"))
-			Expect(logs).To(ContainLines(`    web (default): watchexec --restart --watch /workspace --shell none -- nginx -p /workspace -c /workspace/nginx.conf`))
-			Expect(logs).To(ContainLines(`    no-reload:     nginx -p /workspace -c /workspace/nginx.conf`))
+			Expect(logs).To(ContainLines(
+				"  Assigning launch processes:",
+				"    web (default): watchexec --restart --watch /workspace --shell none -- nginx -p /workspace -c /workspace/nginx.conf -g pid /tmp/nginx.pid;",
+				"    no-reload:     nginx -p /workspace -c /workspace/nginx.conf -g pid /tmp/nginx.pid;",
+			))
 		})
 	})
+
 	context("when build configuration cannot be parsed", func() {
 		it.Before(func() {
 			var err error


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We need to make some minor changes to the buildpack to allow the UIDs to differ between build and run images. Specifically, we need to ensure the default `nginx.conf` file doesn't write to filesystem locations it does not own. That means writing the PID file to `/tmp` and ensuring access and error logs go to stdout and stderr, respectively. Additionally, we need to find and modify the permissions on any configuration files during the build phase so that they can be modified during the run phase if need be.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Resolves #374 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
