### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.8"
   homepage = "https://github.com/paketo-buildpacks/nginx"
   id = "paketo-buildpacks/nginx"
   keywords = ["nginx", "server", "distribution"]
-  name = "Paketo Nginx Server Buildpack"
+  name = "Paketo Buildpack for Nginx Server"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
 [metadata]


### PR DESCRIPTION
Renames 'Paketo Nginx Server Buildpack' to 'Paketo Buildpack for Nginx Server'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
