### PR TITLE
Use occam matcher BeAFileMatching

### DIFF
--- a/cmd/configure/internal/run_test.go
+++ b/cmd/configure/internal/run_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/paketo-buildpacks/nginx/cmd/configure/internal"
+	"github.com/paketo-buildpacks/occam/matchers"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -45,10 +46,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 			err := internal.Run(mainConf, localModulePath, globalModulePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			output, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(string(output)).To(Equal("Hi the port is 8080."))
+			Expect(filepath.Join(workingDir, "nginx.conf")).
+				To(matchers.BeAFileMatching("Hi the port is 8080."))
 		})
 	})
 
@@ -61,10 +60,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 			err := internal.Run(mainConf, localModulePath, globalModulePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			output, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(string(output)).To(Equal(fmt.Sprintf("Hi the tempDir is %s.", os.TempDir())))
+			Expect(filepath.Join(workingDir, "nginx.conf")).
+				To(matchers.BeAFileMatching(fmt.Sprintf("Hi the tempDir is %s.", os.TempDir())))
 		})
 	})
 
@@ -78,10 +75,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 			err := internal.Run(mainConf, localModulePath, globalModulePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			output, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(string(output)).To(Equal("The env var FOO is BAR"))
+			Expect(filepath.Join(workingDir, "nginx.conf")).
+				To(matchers.BeAFileMatching("The env var FOO is BAR"))
 		})
 	})
 
@@ -105,10 +100,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 				err := internal.Run(mainConf, localModulePath, globalModulePath)
 				Expect(err).ToNot(HaveOccurred())
 
-				output, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(string(output)).To(Equal(fmt.Sprintf("load_module %s/local.so;", localModulePath)))
+				Expect(filepath.Join(workingDir, "nginx.conf")).
+					To(matchers.BeAFileMatching(fmt.Sprintf("load_module %s/local.so;", localModulePath)))
 			})
 		})
 
@@ -121,10 +114,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 				err := internal.Run(mainConf, localModulePath, globalModulePath)
 				Expect(err).ToNot(HaveOccurred())
 
-				output, err := os.ReadFile(filepath.Join(workingDir, "nginx.conf"))
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(string(output)).To(Equal(fmt.Sprintf("load_module %s/global.so;", globalModulePath)))
+				Expect(filepath.Join(workingDir, "nginx.conf")).
+					To(matchers.BeAFileMatching(fmt.Sprintf("load_module %s/global.so;", globalModulePath)))
 			})
 		})
 	})
@@ -149,10 +140,8 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 				err := internal.Run(mainConf, localModulePath, globalModulePath)
 				Expect(err).ToNot(HaveOccurred())
 
-				output, err := os.ReadFile(filepath.Join(workingDir, "custom.conf"))
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(string(output)).To(Equal("Hi the port is 8080."))
+				Expect(filepath.Join(workingDir, "custom.conf")).
+					To(matchers.BeAFileMatching("Hi the port is 8080."))
 			})
 		})
 
@@ -178,17 +167,14 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 				err := internal.Run(mainConf, localModulePath, globalModulePath)
 				Expect(err).ToNot(HaveOccurred())
 
-				output, err := os.ReadFile(filepath.Join(workingDir, "dontFix.conf"))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(output)).To(Equal(`Hi the port is {{ port }}.`))
+				Expect(filepath.Join(workingDir, "dontFix.conf")).
+					To(matchers.BeAFileMatching(`Hi the port is {{ port }}.`))
 
-				output, err = os.ReadFile(filepath.Join(workingDir, "subdir", "custom1.conf"))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(output)).To(Equal(`Hi the port is 8080.`))
+				Expect(filepath.Join(workingDir, "subdir", "custom1.conf")).
+					To(matchers.BeAFileMatching(`Hi the port is 8080.`))
 
-				output, err = os.ReadFile(filepath.Join(workingDir, "subdir", "custom2.conf"))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(output)).To(Equal(`Hi the port is 8080.`))
+				Expect(filepath.Join(workingDir, "subdir", "custom2.conf")).
+					To(matchers.BeAFileMatching(`Hi the port is 8080.`))
 			})
 		})
 	})

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -80,9 +80,8 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(container).Should(Serve(ContainSubstring("Hello World!")).WithEndpoint("/index.html"))
 
-			contents, err := os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", "sbom.legacy.json"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(contents)).To(ContainSubstring(`"name":"Nginx Server"`))
+			Expect(filepath.Join(sbomDir, "sbom", "launch", "sbom.legacy.json")).
+				To(BeAFileMatching(ContainSubstring(`"name":"Nginx Server"`)))
 
 			// check that all required SBOM files are present
 			Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "nginx", "sbom.cdx.json")).To(BeARegularFile())
@@ -90,9 +89,8 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "nginx", "sbom.syft.json")).To(BeARegularFile())
 
 			// check an SBOM file to make sure it has an entry
-			contents, err = os.ReadFile(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "nginx", "sbom.cdx.json"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(contents)).To(ContainSubstring(`"name": "Nginx Server"`))
+			Expect(filepath.Join(sbomDir, "sbom", "launch", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"), "nginx", "sbom.cdx.json")).
+				To(BeAFileMatching(ContainSubstring(`"name": "Nginx Server"`)))
 		})
 	})
 


### PR DESCRIPTION
## Summary
Use occam matcher BeAFileMatching.

Blocked on #436 which is why the diff is so big
