### PR TITLE
Fix malformed checksum in retrieval and compile

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -118,7 +118,7 @@ function main() {
     mv temp.tgz "${OUTPUT_TARBALL_NAME}"
 
     echo "Creating checksum file for ${OUTPUT_TARBALL_NAME}"
-    echo "${SHA256}" > "${OUTPUT_SHAFILE_NAME}"
+    echo "sha256:${SHA256}" > "${OUTPUT_SHAFILE_NAME}"
   popd
 }
 

--- a/dependency/retrieval/retrieve.go
+++ b/dependency/retrieval/retrieve.go
@@ -71,9 +71,9 @@ func generateMetadata(hasVersion versionology.VersionFetcher) ([]versionology.De
 	dep := cargo.ConfigMetadataDependency{
 		Version:         nginxVersion,
 		ID:              "nginx",
-		Name:            "NGINX",
+		Name:            "Nginx Server",
 		Source:          nginxURL,
-		SourceChecksum:  sourceSHA,
+		SourceChecksum:  fmt.Sprintf("sha256:%s", sourceSHA),
 		DeprecationDate: nil,
 		Licenses:        retrieve.LookupLicenses(nginxURL, decompress),
 		PURL:            retrieve.GeneratePURL("nginx", nginxVersion, sourceSHA, nginxURL),


### PR DESCRIPTION
Prepends `sha256:` before hash.