### PR TITLE
Make integration test more resilient.

### DIFF
--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -59,23 +59,27 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"  Resolving Nginx Server version",
 				"    Candidate version sources (in priority order):",
 				`      buildpack.yml -> "1.21.*"`,
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				MatchRegexp(`    Selected Nginx Server version \(using buildpack\.yml\): 1\.21\.\d+`),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"    WARNING: Setting the server version through buildpack.yml will be deprecated soon in Nginx Server Buildpack v2.0.0.",
 				"    Please specify the version through the $BP_NGINX_VERSION environment variable instead. See docs for more information.",
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Nginx Server \d+\.\d+\.\d+`),
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Configuring build environment",
 				fmt.Sprintf(`    PATH -> "$PATH:/layers/%s/nginx/sbin"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Configuring launch environment",
 				`    EXECD_CONF -> "/workspace/nginx.conf"`,
 				fmt.Sprintf(`    PATH       -> "$PATH:/layers/%s/nginx/sbin"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				"",
 			))
 		})
 	})
@@ -97,20 +101,23 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				`      BP_NGINX_VERSION -> "1.22.*"`,
 				`      buildpack.yml    -> "1.21.*"`,
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				MatchRegexp(`    Selected Nginx Server version \(using BP_NGINX_VERSION\): 1\.22\.\d+`),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Executing build process",
 				MatchRegexp(`    Installing Nginx Server \d+\.\d+\.\d+`),
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Configuring build environment",
 				fmt.Sprintf(`    PATH -> "$PATH:/layers/%s/nginx/sbin"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				"",
+			))
+			Expect(logs).To(matchers.ContainLines(
 				"  Configuring launch environment",
 				`    EXECD_CONF -> "/workspace/nginx.conf"`,
 				fmt.Sprintf(`    PATH       -> "$PATH:/layers/%s/nginx/sbin"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				"",
 			))
 		})
 	})

--- a/integration/no_conf_app_test.go
+++ b/integration/no_conf_app_test.go
@@ -266,13 +266,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).ToNot(HaveOccurred())
 
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s/stub_status", container.HostPort("8083")))
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			contents, err := io.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(contents)).To(ContainSubstring("Active connections: 1"))
+			Eventually(container).Should(Serve(ContainSubstring("Active connections: 1")).OnPort(8083).WithEndpoint("/stub_status"))
 		})
 	})
 }

--- a/integration/no_conf_app_test.go
+++ b/integration/no_conf_app_test.go
@@ -70,7 +70,6 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				"  Generating /workspace/nginx.conf",
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
 				"    Setting server location path to '/'",
-				"",
 			))
 
 			container, err = docker.Container.Run.
@@ -86,7 +85,7 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 	context("when using env var configuration options", func() {
 		it.Before(func() {
 			Expect(fs.Copy(filepath.Join(source, "public"), filepath.Join(source, "custom_root"))).To(Succeed())
-			os.RemoveAll(filepath.Join(source, "public"))
+			Expect(os.RemoveAll(filepath.Join(source, "public"))).To(Succeed())
 		})
 
 		it("generates an nginx.conf with the configuration", func() {
@@ -118,7 +117,6 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/custom_root'`,
 				"    Setting server location path to '/custom_path'",
 				"    Enabling push state routing",
-				"",
 			))
 
 			Eventually(container).Should(Serve(ContainSubstring("<p>Hello World!</p>")).OnPort(8080).WithEndpoint("/custom_path"))
@@ -148,7 +146,6 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
 				"    Setting server location path to '/'",
 				`    Setting server to redirect HTTP requests to HTTPS`,
-				"",
 			))
 
 			container, err = docker.Container.Run.
@@ -203,7 +200,6 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
 				"    Setting server location path to '/'",
 				`    Enabling basic authentication with .htpasswd credentials`,
-				"",
 			))
 
 			container, err = docker.Container.Run.
@@ -214,9 +210,14 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Assert that unauthenticated requests fail
-			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
-			Expect(err).NotTo(HaveOccurred())
+			var response *http.Response
+			Eventually(func() error {
+				var err error
+				response, err = http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				return err
+			}).Should(Succeed())
 			defer response.Body.Close()
+
 			Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
 
 			// And that authenticated requests succeed
@@ -225,12 +226,16 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 
 			req.SetBasicAuth("user", "password")
 
-			response, err = http.DefaultClient.Do(req)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				var err error
+				response, err = http.DefaultClient.Do(req)
+				return err
+			}).Should(Succeed())
 			defer response.Body.Close()
 
 			contents, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
+
 			Expect(string(contents)).To(ContainSubstring("Hello World!"))
 		})
 	})
@@ -257,7 +262,6 @@ func testNoConfApp(t *testing.T, context spec.G, it spec.S) {
 				`    Setting server root directory to '{{ env "APP_ROOT" }}/public'`,
 				"    Setting server location path to '/'",
 				`    Enabling basic status information with stub_status module`,
-				"",
 			))
 
 			container, err = docker.Container.Run.


### PR DESCRIPTION
## Summary

This PR fixes a flaky integration test. An example failure can be seen [here](https://github.com/paketo-buildpacks/nginx/actions/runs/4508621624/jobs/8010143751?pr=524).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
