### PR TITLE
dependency/retreival: add Sergey Kandaurov's PGP public key

### DIFF
--- a/dependency/retrieval/retrieve.go
+++ b/dependency/retrieval/retrieve.go
@@ -158,10 +158,12 @@ func getGPGKeys() ([]string, error) {
 	var nginxGPGKeys []string
 	for _, keyURL := range []string{
 		// Key URLs from https://nginx.org/en/pgp_keys.html
-		"http://nginx.org/keys/mdounin.key",
-		"http://nginx.org/keys/maxim.key",
-		"http://nginx.org/keys/sb.key",
-		"http://nginx.org/keys/thresh.key",
+		"http://nginx.org/keys/mdounin.key",        // Maxim Dounin’s PGP public key
+		"http://nginx.org/keys/maxim.key",          // Maxim Konovalov’s PGP public key
+		"https://nginx.org/keys/pluknet.key",       // Sergey Kandaurov’s PGP public key
+		"http://nginx.org/keys/sb.key",             // Sergey Budnevitch’s PGP public key
+		"http://nginx.org/keys/thresh.key",         // Konstantin Pavlov’s PGP public key
+		"https://nginx.org/keys/nginx_signing.key", // nginx public key
 	} {
 		body, err := httpGet(keyURL)
 		if err != nil {


### PR DESCRIPTION
See https://nginx.org/en/pgp_keys.html [1], it lists Sergey Kandaurov as authorized signatory, yet his keys were missing from the public key list (he signed this release). Pre-1.25.4, most releases seem to have been signed by the 2 Maxims and Konstantin and that's why our CI's gpg verification passed. Also add the "nginx public key" while we're at it.

Fixes: https://github.com/paketo-buildpacks/nginx/actions/runs/7974658386/job/21772993602

**Interesting** (probably related):
From 1.25.4, it seems like some maintainers have started an nginx fork called Freenginx https://freenginx.org/

**Footnotes**:
1 - if you're looking at this a long time after this comment, look up
  the url via web.archive.org

![Screenshot 2024-02-21 at 3 13 41 PM](https://github.com/paketo-buildpacks/nginx/assets/2861611/c5cb529f-4201-4638-9a20-042a05047545)

