### PR TITLE
retrieval: s/M Dounin/R Arutyunyan/ public key

### DIFF
--- a/dependency/retrieval/retrieve.go
+++ b/dependency/retrieval/retrieve.go
@@ -158,8 +158,8 @@ func getGPGKeys() ([]string, error) {
 	var nginxGPGKeys []string
 	for _, keyURL := range []string{
 		// Key URLs from https://nginx.org/en/pgp_keys.html
-		"http://nginx.org/keys/mdounin.key",        // Maxim Dounin’s PGP public key
 		"http://nginx.org/keys/maxim.key",          // Maxim Konovalov’s PGP public key
+		"http://nginx.org/keys/arut.key",           // Roman Arutyunyan's PGP public key
 		"https://nginx.org/keys/pluknet.key",       // Sergey Kandaurov’s PGP public key
 		"http://nginx.org/keys/sb.key",             // Sergey Budnevitch’s PGP public key
 		"http://nginx.org/keys/thresh.key",         // Konstantin Pavlov’s PGP public key

--- a/integration.json
+++ b/integration.json
@@ -4,5 +4,5 @@
     "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
   ],
   "build-plan": "github.com/paketo-community/build-plan",
-  "watchexec": "github.com/paketo-buildpacks/watchexec"
+  "watchexec": "index.docker.io/paketobuildpacks/watchexec"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -76,9 +76,7 @@ func TestIntegration(t *testing.T) {
 		Execute(root)
 	Expect(err).NotTo(HaveOccurred())
 
-	settings.Buildpacks.Watchexec.Online, err = libpakBuildpackStore.Get.
-		Execute(settings.Config.Watchexec)
-	Expect(err).ToNot(HaveOccurred())
+	settings.Buildpacks.Watchexec.Online = settings.Config.Watchexec
 
 	settings.Buildpacks.BuildPlan.Online, err = libpakBuildpackStore.Get.
 		Execute(settings.Config.BuildPlan)

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -184,7 +184,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.Watchexec.Online,
 					settings.Buildpacks.NGINX.Online,
 				).
-				WithPullPolicy("never").
+				WithPullPolicy("if-not-present").
 				WithEnv(map[string]string{
 					"BP_LIVE_RELOAD_ENABLED": "true",
 				}).
@@ -235,7 +235,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.Watchexec.Online,
 					settings.Buildpacks.NGINX.Online,
 				).
-				WithPullPolicy("never").
+				WithPullPolicy("if-not-present").
 				WithEnv(map[string]string{
 					"BP_LIVE_RELOAD_ENABLED": "not-a-bool",
 				}).


### PR DESCRIPTION
It looks like a signer maintainer left, and a new signer joined the maintainer team.

See current list of signers:
<img width="603" alt="Screenshot 2024-04-24 at 4 59 06 PM" src="https://github.com/paketo-buildpacks/nginx/assets/2861611/48bcab3a-6ce8-41a7-a1ee-b6b40a55902e">


See similar PR in the past: https://github.com/paketo-buildpacks/nginx/pull/692 



- Also use watchexec buildpack image directly in tests.
See paketo-buildpacks/libpak#321, create-package
is not able to support multiarch buildpacks and watchexec was just released
multiarch

