### PR TITLE
fix(config): generate

### DIFF
--- a/default_config_generator.go
+++ b/default_config_generator.go
@@ -24,6 +24,21 @@ func NewDefaultConfigGenerator(logs scribe.Emitter) DefaultConfigGenerator {
 }
 
 func (g DefaultConfigGenerator) Generate(config Configuration) error {
+	g.logs.Process("Check: %s", config.NGINXConfLocation)
+	if info, err := os.Stat(config.NGINXConfLocation); err == nil {
+		g.logs.Subprocess("Configuration file already exists")
+		if info.Size() > 0 {
+			userConf, err := os.ReadFile(config.NGINXConfLocation)
+			if err != nil {
+				return err
+			}
+
+			g.logs.Subprocess("Set configuration (in %s) as template", config.NGINXConfLocation)
+
+			DefaultConfigTemplate = string(userConf)
+		}
+	}
+
 	g.logs.Process("Generating %s", config.NGINXConfLocation)
 	t := template.Must(template.New("template.conf").Delims("$((", "))").Parse(DefaultConfigTemplate))
 


### PR DESCRIPTION
this commit ensures that an existing nginx.conf is not overwritten by
the config generator of the buildpack. for cases where a consumer of
the buildpack used an empty nginx.conf to trigger inclusion of the
buildpack in the plan, the generator will generate a full nginx.conf
according to the buildpack's defaults.

related: #667

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
